### PR TITLE
Better sidebar and stats "alerts"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -74,7 +74,9 @@
             </button>
           </div>
           <div id="map" class="h-100"></div>
-          <div id="js-trip-stats-container" class="trip-stats-container col-sm-9"></div>
+          <div class="trip-stats-container col-sm-9">
+            <div id="js-trip-stats-container" class="row px-2"></div> 
+          </div>
         </div>
         <div class="col-xs-10 col-sm-3 map-overlay-pane map-overlay-pane--collapsed js-sliding-pane pt-2">
           <div class="row pb-3">

--- a/src/index.html
+++ b/src/index.html
@@ -74,7 +74,7 @@
             </button>
           </div>
           <div id="map" class="h-100"></div>
-          <div id="js-trip-stats-container--mobile" class="trip-stats-container--mobile"></div>
+          <div id="js-trip-stats-container" class="trip-stats-container col-sm-9"></div>
         </div>
         <div class="col-xs-10 col-sm-3 map-overlay-pane map-overlay-pane--collapsed js-sliding-pane pt-2">
           <div class="row pb-3">
@@ -96,32 +96,28 @@
             </div>
           </div>
             <form id="js-daterange-select-form" action="#">
-              <div class="form-group row">
-                <label for="js-start-date-select" class="col-sm-4 col-form-label">Start Date</label>
-                <div class="col-sm-8">
+              <div class="form-row">
+                <div class="form-group col-6 mb-0">
+                  <label for="js-start-date-select" class="col-form-label">Start Date</label>
                   <input id="js-start-date-select" class="form-control" data-toggle="datepicker">
                 </div>
-              </div>
-              <div class="form-group row">
-                <label for="js-end-date-select" class="col-sm-4 col-form-label">End Date</label>
-                <div class="col-sm-8">
+                <div class="form-group col-6 mb-0">
+                  <label for="js-end-date-select" class="col-form-label">End Date</label>
                   <input id="js-end-date-select" class="form-control" data-toggle="datepicker">
                 </div>
               </div>
             </form>
             <form id="js-mode-flow-select-form" action="#">
-              <div class="form-group row">
-                <label for="flow-select" class="col-sm-3 col-form-label">Flow</label>
-                <div class="col-sm-9">
+              <div class="form-row">
+                <div class="form-group col-6 mb-0">
+                  <label for="flow-select" class="col-form-label">Trip Flow</label>
                   <select class="form-control js-flow-select" id="flow-select">
-                    <option value="destination" selected="selected">Trip Destinations</option>
-                    <option value="origin">Trip Origins</option>
+                    <option value="destination" selected="selected">Destinations</option>
+                    <option value="origin">Origins</option>
                   </select>
                 </div>
-              </div>
-              <div class="form-group row">
-                <label for="mode-select" class="col-sm-3 col-form-label">Mode</label>
-                <div class="col-sm-9">
+                <div class="form-group col-6 mb-0">
+                  <label for="mode-select" class="col-form-label">Mode</label>
                   <select class="form-control js-mode-select" id="mode-select">
                     <option value="all">All</option>
                     <option value="scooter">Scooter</option>

--- a/src/index.html
+++ b/src/index.html
@@ -140,11 +140,6 @@
               </span>
             </button>
           </div>
-          <p class="disclaimer text-justify position-absolute mr-3">
-            <i>
-              This map has been produced by the City of Austin for the sole purpose of geographic reference. No warranty is made by the City of Austin regarding specific accuracy or completeness.
-            </i>
-          </p>
         </div>
       </div>
 
@@ -186,6 +181,11 @@
               <div class="text-center mb-2">
                 <img src="/coa_seaL_lg.jpeg" alt="City of Austin Seal" class="city-seal-img">
               </div>
+              <p class="disclaimer mt-3">
+                <i>
+                  This map has been produced by the City of Austin for the sole purpose of geographic reference. No warranty is made by the City of Austin regarding specific accuracy or completeness.
+                </i>
+              </p>
             </div>
             <div class="modal-footer">
               <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/src/index.html
+++ b/src/index.html
@@ -75,7 +75,7 @@
           </div>
           <div id="map" class="h-100"></div>
           <div class="trip-stats-container col-sm-9">
-            <div id="js-trip-stats-container" class="row px-2"></div> 
+            <div id="js-trip-stats-container" class="row justify-content-center px-3"></div>
           </div>
         </div>
         <div class="col-xs-10 col-sm-3 map-overlay-pane map-overlay-pane--collapsed js-sliding-pane pt-2">

--- a/src/index.js
+++ b/src/index.js
@@ -207,21 +207,13 @@ const ATD_DocklessMap = (function() {
       }
 
       const html = `
-        <div id="js-cell-trip-count" class="d-none d-sm-block alert alert-dark stats" role="alert">
-         ${text}
-         </div>
-      `;
-
-      const htmlMobile = `
-        <div id="js-cell-trip-count--mobile" class="d-sm-none alert alert-dark stats trip-alert--mobile" role="alert">
+        <div id="js-cell-trip-count" class="alert alert-dark stats trip-alert--mobile" role="alert">
          ${text}
          </div>
       `;
 
       $("#js-cell-trip-count").remove();
-      $("#js-cell-trip-count--mobile").remove();
-      $("#js-data-pane").append(html);
-      $("#js-trip-stats-container--mobile").append(htmlMobile);
+      $("#js-trip-stats-container").append(html);
     }
 
     const showLayer = (layer_name, show_layer) => {
@@ -686,21 +678,14 @@ const ATD_DocklessMap = (function() {
     }
 
     const html = `
-      <div id="js-trip-alert" class="d-none d-sm-block alert alert-primary stats" role="alert">
-        ${text}
-      </div>`;
-
-    const htmlMobile = `
-      <div id="js-trip-alert--mobile" class="d-sm-none alert alert-primary stats trip-alert--mobile" role="alert">
+      <div id="js-trip-alert" class="alert alert-primary stats trip-alert--mobile" role="alert">
         ${text}
       </div>
     `;
 
     $("#js-trip-alert").remove();
-    $("#js-trip-alert--mobile").remove();
     $("#js-cell-trip-count").remove();
-    $(`#${divId}`).append(html);
-    $("#js-trip-stats-container--mobile").append(htmlMobile);
+    $("#js-trip-stats-container").append(html);
   };
 
   const openSlidingPane = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -197,17 +197,17 @@ const ATD_DocklessMap = (function() {
           feature.properties.trips
         )} (${docklessMap.formatPct(
           trip_percent
-        )}) trips started in the clicked cell.`;
+        )}) trips started in the selected cell.`;
       } else if (docklessMap.flow === "destination") {
         text = `${docklessMap.formatKs(
           feature.properties.trips
         )} (${docklessMap.formatPct(
           trip_percent
-        )}) trips ended in the clicked cell.`;
+        )}) trips ended in the selected cell.`;
       }
 
       const html = `
-        <div id="js-cell-trip-count" class="alert alert-dark col-xs-12 col-md-6" role="alert">
+        <div id="js-cell-trip-count" class="alert alert-purple col-xs-12 col-md-5 ml-sm-2 js-stats-alert" role="alert">
          ${text}
          </div>
       `;
@@ -552,7 +552,7 @@ const ATD_DocklessMap = (function() {
     `);
   };
 
-  const removeStats = (selector = "stats") => {
+  const removeStats = (selector = "js-stats-alert") => {
     $("." + selector).remove();
   };
 
@@ -670,15 +670,15 @@ const ATD_DocklessMap = (function() {
     if (docklessMap.flow === "origin") {
       text = `${docklessMap.formatKs(
         total_trips
-      )} trips terminated in the selected area.`;
+      )} trips terminated in the outlined area.`;
     } else if (docklessMap.flow === "destination") {
       text = `${docklessMap.formatKs(
         total_trips
-      )}  trips originated in the selected area.`;
+      )}  trips originated in the outlined area.`;
     }
 
     const html = `
-      <div id="js-trip-alert" class="alert alert-primary col-xs-12 col-md-6" role="alert">
+      <div id="js-trip-alert" class="alert alert-secondary alert-dashed-border col-xs-12 col-md-5 mr-sm-2 js-stats-alert" role="alert">
         ${text}
       </div>
     `;

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ const ATD_DocklessMap = (function() {
       }
 
       const html = `
-        <div id="js-cell-trip-count" class="alert alert-dark stats trip-alert--mobile" role="alert">
+        <div id="js-cell-trip-count" class="alert alert-dark col-xs-12 col-md-6" role="alert">
          ${text}
          </div>
       `;
@@ -678,7 +678,7 @@ const ATD_DocklessMap = (function() {
     }
 
     const html = `
-      <div id="js-trip-alert" class="alert alert-primary stats trip-alert--mobile" role="alert">
+      <div id="js-trip-alert" class="alert alert-primary col-xs-12 col-md-6" role="alert">
         ${text}
       </div>
     `;

--- a/src/style.css
+++ b/src/style.css
@@ -107,12 +107,12 @@
   width: 100%;
 }
 
-.trip-stats-container--mobile {
+.trip-stats-container {
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  margin: 1rem;
+  margin-bottom: 1rem;
 }
 
 /* Spinner */

--- a/src/style.css
+++ b/src/style.css
@@ -115,6 +115,16 @@
   margin-bottom: 1rem;
 }
 
+.alert-dashed-border {
+  border: 2px dashed rgba(56, 61, 65, 0.55);
+}
+
+.alert-purple {
+  color: #433f5f;
+  background-color: #dcdaec;
+  border-color: #756bb1;
+}
+
 /* Spinner */
 /*https://projects.lukehaas.me/css-loaders/*/
 .loader,


### PR DESCRIPTION
Closes #86 

- moves inputs into 2-column rows.
- moves disclaimer into welcome modal
- styling (and small copy) changes to "alert" dialog boxes for trip stats
   - The idea here was to make each of the dialogs visually resemble map features. dashed area for the first, purple background for the selected cell. Very open to feedback on this implementation but hopefully its more intuitive for ppl.

![screen shot 2018-12-26 at 4 26 48 pm](https://user-images.githubusercontent.com/5697474/50458781-67ba0a00-092b-11e9-9f34-7666a0869e05.png)

![screen shot 2018-12-27 at 12 14 07 pm](https://user-images.githubusercontent.com/5697474/50490106-f7fe5a80-09d0-11e9-92ca-9e7d5f2f7d82.png)

![screen shot 2018-12-27 at 1 02 31 pm](https://user-images.githubusercontent.com/5697474/50491623-def9a780-09d8-11e9-8357-e3151d594432.png)

![screen shot 2018-12-27 at 1 02 12 pm](https://user-images.githubusercontent.com/5697474/50491629-e4ef8880-09d8-11e9-8806-dbe35321a7dc.png)

![screen shot 2018-12-27 at 1 02 16 pm](https://user-images.githubusercontent.com/5697474/50491637-ea4cd300-09d8-11e9-8a82-b0f6eddae67c.png)

