### PR TITLE
Fix tutorial tooltip in Firefox

### DIFF
--- a/src/modules/tutorial.js
+++ b/src/modules/tutorial.js
@@ -68,20 +68,20 @@ function setTutorialStep4And5() {
     // Tilt doesn't really work on mobile so we need to skip this step on small
     // devices.
     if (window.innerWidth < BOOTSTRAP_SM_BREAKPOINT) {
-      runTutorialStep5(".mapboxgl-ctrl-compass-arrow");
+      runTutorialStep5(".mapboxgl-ctrl-compass");
     } else {
       setTooltip(
-        ".mapboxgl-ctrl-compass-arrow",
+        ".mapboxgl-ctrl-compass",
         "right",
         "Click & drag here to tilt the map"
       );
-      showTooltip(".mapboxgl-ctrl-compass-arrow");
+      showTooltip(".mapboxgl-ctrl-compass");
 
       // set the next step's trigger based on device width
-      $(".mapboxgl-ctrl-compass-arrow").on("mousedown.step5", () => {
+      $(".mapboxgl-ctrl-compass").on("mousedown.step5", () => {
         runTutorialStep5();
-        $(".mapboxgl-ctrl-compass-arrow").off("mousedown.step5");
-        $(".mapboxgl-ctrl-compass-arrow").tooltip("hide");
+        $(".mapboxgl-ctrl-compass").off("mousedown.step5");
+        $(".mapboxgl-ctrl-compass").tooltip("hide");
       });
     }
 


### PR DESCRIPTION
Fixes #77

Instead of using the `<span class="mapboxgl-ctrl-compass-arrow">`, I updated the code to use `<button class="mapboxgl-ctrl-compass">` as the anchor for the tooltip and mousedown event.

This seems to do the trick for me on Firefox 63.0.3 for Mac. @BryceDerriso thanks for finding this bug!! Let me know if this is reproducible for you after this patch.

staging deployment: https://deploy-preview-88--dockless.netlify.com/